### PR TITLE
Add Webassembly, Atomics, and other things

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.'cfg(all(not(target_os = "emscripten"), target_family = "wasm"))']
+runner = 'wasm-bindgen-test-runner'

--- a/.travis.yml
+++ b/.travis.yml
@@ -261,3 +261,23 @@ matrix:
     #   nightly 
     - env: TARGET=asmjs-unknown-emscripten
       rust: nightly 
+    # WASI
+    #   stable
+    - env: TARGET=wasm32-wasi
+      rust: stable
+    #   beta
+    - env: TARGET=wasm32-wasi
+      rust: beta
+    #   nightly
+    - env: TARGET=wasm32-wasi
+      rust: nightly
+    # WebAssembly
+    #   stable
+    - env: TARGET=wasm32-unknown-unknown
+      rust: stable
+    #   beta
+    - env: TARGET=wasm32-unknown-unknown
+      rust: beta
+    #   nightly
+    - env: TARGET=wasm32-unknown-unknown
+      rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Elzair/page_size_rs"
 repository = "https://github.com/Elzair/page_size_rs"
 keywords = ["page", "memory", "ram", "page_size"]
 categories = ["os"]
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "Elzair/page_size_rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ travis-ci = { repository = "Elzair/page_size_rs" }
 appveyor = { repository = "Elzair/page_size_rs" }
 
 [features]
-no_std = ["spin"]
+std = []
+default = ["std"]
 
 [dependencies]
-spin = { version = "0.5.2", optional = true }
+once_cell = { version = "1.10.0", default-features = false, features = ["race"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Elzair/page_size_rs"
 repository = "https://github.com/Elzair/page_size_rs"
 keywords = ["page", "memory", "ram", "page_size"]
 categories = ["os"]
-# edition = "2021"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "Elzair/page_size_rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/Elzair/page_size_rs"
 repository = "https://github.com/Elzair/page_size_rs"
 keywords = ["page", "memory", "ram", "page_size"]
 categories = ["os"]
+# edition = "2021"
 
 [badges]
 travis-ci = { repository = "Elzair/page_size_rs" }
@@ -20,6 +21,9 @@ no_std = ["spin"]
 
 [dependencies]
 spin = { version = "0.5.2", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.29"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`page_size_rs` is a Rust crate that provides an easy, fast, cross-platform way to retrieve the memory page size of the current system. It supports any POSIX-compliant system and Windows.
+`page_size_rs` is a Rust crate that provides an easy, fast, cross-platform way to retrieve the memory page size of the current system. It supports any POSIX-compliant system, Windows, and WebAssembly.
 
 [Documentation](https://docs.rs/page_size)
 
@@ -25,7 +25,7 @@ fn main() {
 
 # Platforms
 
-`page_size_rs` should Work on Windows and any POSIX compatible system (Linux, Mac OSX, etc.).
+`page_size_rs` should Work on Windows, any POSIX compatible system (Linux, Mac OSX, etc.), and WebAssembly.
 
 `page_size_rs` is continuously tested on:
   * `x86_64-unknown-linux-gnu` (Linux)
@@ -54,3 +54,5 @@ fn main() {
   * `x86_64-unknown-freebsd`
   * `x86_64-unknown-netbsd`
   * `asmjs-unknown-emscripten`
+  * `wasm32-wasi`
+  * `wasm32-unknown-unknown`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ mod unix {
 
 // WebAssembly does not have a specific allocation granularity.
 // The page size works well.
-#[cfg(all(not(target_os = "emscripten"), any(target_arch = "wasm32", target_arch = "wasm64")))]
+#[cfg(all(not(target_os = "emscripten"), target_family = "wasm"))]
 #[inline]
 fn get_granularity_helper() -> usize {
     // <https://webassembly.github.io/spec/core/exec/runtime.html#page-size>
@@ -210,6 +210,25 @@ mod tests {
     }    
 
     #[test]
+    fn test_get_granularity() {
+        #[allow(unused_variables)]
+        let granularity = get_granularity();
+    }
+}
+
+/// Normal tests will do nothing inside WASM
+#[cfg(all(test, not(target_os = "emscripten"), target_family = "wasm"))]
+mod wasm_tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    fn test_get() {
+        #[allow(unused_variables)]
+        let page_size = get();
+    }    
+
+    #[wasm_bindgen_test]
     fn test_get_granularity() {
         #[allow(unused_variables)]
         let granularity = get_granularity();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ mod unix {
 
 // WebAssembly does not have a specific allocation granularity.
 // The page size works well.
-#[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+#[cfg(all(not(target_os = "emscripten"), any(target_arch = "wasm32", target_arch = "wasm64")))]
 #[inline]
 fn get_granularity_helper() -> usize {
     // <https://webassembly.github.io/spec/core/exec/runtime.html#page-size>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! after it has been called once.
 //!
 //! To make this crate useful for writing memory allocators, it does not require
-//! (but can use) the Rust standard library. 
+//! (but can use) the Rust standard library.
 //!
 //! Since Windows addresses sometimes have to correspond with an allocation
 //! granularity that does not always match the size of the page, I have included
@@ -22,24 +22,11 @@
 //! println!("{}", page_size::get());
 //! ```
 
-// `const_fn` is needed for `spin::Once`.
-#![cfg_attr(feature = "no_std", feature(const_fn))]
-
-#[cfg(feature = "no_std")]
-extern crate spin;
-#[cfg(feature = "no_std")]
-use spin::Once;
-
-#[cfg(not(feature = "no_std"))]
+// wasm test runtime needs std
+#[cfg(all(test, not(target_os = "emscripten"), target_family = "wasm"))]
 extern crate std;
-#[cfg(not(feature = "no_std"))]
-use std::sync::Once;
 
-#[cfg(unix)]
-extern crate libc;
-
-#[cfg(windows)]
-extern crate winapi;
+use once_cell::race::OnceNonZeroUsize;
 
 /// This function retrieves the system's memory page size.
 ///
@@ -67,24 +54,11 @@ pub fn get_granularity() -> usize {
 
 // Unix Section
 
-#[cfg(all(unix, feature = "no_std"))]
+#[cfg(unix)]
 #[inline]
 fn get_helper() -> usize {
-    static INIT: Once<usize> = Once::new();
-    
-    *INIT.call_once(unix::get)
-}
-
-#[cfg(all(unix, not(feature = "no_std")))]
-#[inline]
-fn get_helper() -> usize {
-    static INIT: Once = Once::new();
-    static mut PAGE_SIZE: usize = 0;
-
-    unsafe {
-        INIT.call_once(|| PAGE_SIZE = unix::get());
-        PAGE_SIZE
-    }
+    static PAGE_SIZE: OnceNonZeroUsize = OnceNonZeroUsize::new();
+    PAGE_SIZE.get_or_init(unix::get).get()
 }
 
 // Unix does not have a specific allocation granularity.
@@ -97,103 +71,81 @@ fn get_granularity_helper() -> usize {
 
 #[cfg(unix)]
 mod unix {
-    use libc::{_SC_PAGESIZE, sysconf};
+    use core::num::NonZeroUsize;
+
+    use libc::{sysconf, _SC_PAGESIZE};
 
     #[inline]
-    pub fn get() -> usize {
-        unsafe {
-            sysconf(_SC_PAGESIZE) as usize
-        }
+    pub fn get() -> NonZeroUsize {
+        unsafe { NonZeroUsize::new(sysconf(_SC_PAGESIZE) as usize).unwrap() }
     }
 }
 
 // WebAssembly section
+
+#[cfg(all(not(target_os = "emscripten"), target_family = "wasm"))]
+#[inline]
+fn get_helper() -> usize {
+    // <https://webassembly.github.io/spec/core/exec/runtime.html#page-size>
+    65536
+}
 
 // WebAssembly does not have a specific allocation granularity.
 // The page size works well.
 #[cfg(all(not(target_os = "emscripten"), target_family = "wasm"))]
 #[inline]
 fn get_granularity_helper() -> usize {
-    // <https://webassembly.github.io/spec/core/exec/runtime.html#page-size>
-    65536
+    get_helper()
 }
 
 // Windows Section
 
-#[cfg(all(windows, feature = "no_std"))]
+#[cfg(windows)]
 #[inline]
 fn get_helper() -> usize {
-    static INIT: Once<usize> = Once::new();
-    
-    *INIT.call_once(windows::get)
+    static PAGE_SIZE: OnceNonZeroUsize = OnceNonZeroUsize::new();
+    PAGE_SIZE.get_or_init(windows::get).get()
 }
 
-#[cfg(all(windows, not(feature = "no_std")))]
-#[inline]
-fn get_helper() -> usize {
-    static INIT: Once = Once::new();
-    static mut PAGE_SIZE: usize = 0;
-
-    unsafe {
-        INIT.call_once(|| PAGE_SIZE = windows::get());
-        PAGE_SIZE
-    }
-}
-
-#[cfg(all(windows, feature = "no_std"))]
+#[cfg(windows)]
 #[inline]
 fn get_granularity_helper() -> usize {
-    static GRINIT: Once<usize> = Once::new();
-    
-    *GRINIT.call_once(windows::get_granularity)
-}
-
-#[cfg(all(windows, not(feature = "no_std")))]
-#[inline]
-fn get_granularity_helper() -> usize {
-    static GRINIT: Once = Once::new();
-    static mut GRANULARITY: usize = 0;
-
-    unsafe {
-        GRINIT.call_once(|| GRANULARITY = windows::get_granularity());
-        GRANULARITY
-    }
+    static GRANULARITY: OnceNonZeroUsize = OnceNonZeroUsize::new();
+    GRANULARITY.get_or_init(windows::get_granularity).get()
 }
 
 #[cfg(windows)]
 mod windows {
-    #[cfg(feature = "no_std")]
     use core::mem;
-    #[cfg(not(feature = "no_std"))]
-    use std::mem;
-    
-    use winapi::um::sysinfoapi::{SYSTEM_INFO, LPSYSTEM_INFO};
+    use core::num::NonZeroUsize;
+
     use winapi::um::sysinfoapi::GetSystemInfo;
+    use winapi::um::sysinfoapi::{LPSYSTEM_INFO, SYSTEM_INFO};
 
     #[inline]
-    pub fn get() -> usize {
+    pub fn get() -> NonZeroUsize {
         unsafe {
             let mut info: SYSTEM_INFO = mem::zeroed();
             GetSystemInfo(&mut info as LPSYSTEM_INFO);
 
-            info.dwPageSize as usize
+            NonZeroUsize::new(info.dwPageSize as usize).unwarp()
         }
     }
 
     #[inline]
-    pub fn get_granularity() -> usize {
+    pub fn get_granularity() -> NonZeroUsize {
         unsafe {
             let mut info: SYSTEM_INFO = mem::zeroed();
             GetSystemInfo(&mut info as LPSYSTEM_INFO);
 
-            info.dwAllocationGranularity as usize
+            NonZeroUsize::new(info.dwAllocationGranularity as usize).unwarp()
         }
     }
 }
 
 // Stub Section
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(not(any(unix, windows, target_family = "wasm")))]
 #[inline]
 fn get_helper() -> usize {
     4096 // 4k is the default on many systems
@@ -202,12 +154,12 @@ fn get_helper() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_get() {
         #[allow(unused_variables)]
         let page_size = get();
-    }    
+    }
 
     #[test]
     fn test_get_granularity() {
@@ -226,7 +178,7 @@ mod wasm_tests {
     fn test_get() {
         #[allow(unused_variables)]
         let page_size = get();
-    }    
+    }
 
     #[wasm_bindgen_test]
     fn test_get_granularity() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,17 @@ mod unix {
     }
 }
 
+// WebAssembly section
+
+// WebAssembly does not have a specific allocation granularity.
+// The page size works well.
+#[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+#[inline]
+fn get_granularity_helper() -> usize {
+    // <https://webassembly.github.io/spec/core/exec/runtime.html#page-size>
+    65536
+}
+
 // Windows Section
 
 #[cfg(all(windows, feature = "no_std"))]


### PR DESCRIPTION
- Use atomics instead of spinlock (see https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html)
- Rolls up Web Assembly support from #3 (and make `get_helper` also return 64Ki), Web assembly does not support atomics, but since its a never changing value that is ok.
- Adds ability to test Web Assembly target
- Use feature gate `std` with `default = ["std"]` for more ergonomic use
- Bump rust edition to 2021 for cleaner looking modules & imports

### Notes
This makes breaking changes.

Atomics not supported on some arm microcontrollers, In which case it will give a compiler error complaining about `NonZeroUsize` being missing, but that is another edge cage with an eventual solution with unstable `#[cfg(target_has_atomic = ...)]`  and [atomics polyfill](https://github.com/embassy-rs/atomic-polyfill)
issue: rust-lang/rust/issues/32976