### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "Elzair/page_size_rs" }
 no_std = ["spin"]
 
 [dependencies]
-spin = { version = "^0.9", optional = true }
+spin = { version = "0.9.8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "^0.2"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)